### PR TITLE
Disable default latest tag for .NET 9

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
     uses: swissgrc/.github/.github/workflows/publish-image.yml@main
     with:
       image-name: swissgrc/azure-pipelines-node
-      default-latest-tag: true
+      default-latest-tag: false
       additional-latest-tag-name: latest-24-net9
-      default-unstable-tag: true
+      default-unstable-tag: false
       additional-unstable-tag-name: unstable-24-net9
       release-tag-suffix: net9
     secrets:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ The following example shows the container used for a deployment step with a Azur
 
 | Tag              | Description                                          | Size                                                                                                                                  |
 |------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
-| latest           | Latest stable release (from `main` branch)           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-node/latest?style=flat-square)           |
-| latest-24-net9   | Indentical to `latest` tag                           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-node/latest-24-net9?style=flat-square)   |
-| unstable         | Latest unstable release (from `develop` branch)      | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-node/unstable?style=flat-square)         |
-| unstable-24-net9 | Indentical to `unstable` tag                         | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-node/unstable-24-net9?style=flat-square) |
+| latest-24-net9   | Latest stable release (from `main` branch)           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-node/latest-24-net9?style=flat-square)   |
+| unstable-24-net9 | Latest unstable release (from `develop` branch)      | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-node/unstable-24-net9?style=flat-square) |
 | x.y.z-net9       | Image for a specific version of Node.js              |                                                                                                                                       |
 
 [Azure Pipelines container jobs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases


### PR DESCRIPTION
Disable default latest tag for .NET 9 as we now released a .NET 10 version of the image.